### PR TITLE
Adiciona mock do serviço de cache 

### DIFF
--- a/tests/UseCases.Test/Cadastro/RecuperarPorId/RecuperarCadastroPorIdUseCaseTest.cs
+++ b/tests/UseCases.Test/Cadastro/RecuperarPorId/RecuperarCadastroPorIdUseCaseTest.cs
@@ -32,7 +32,8 @@ public class RecuperarCadastroPorIdUseCaseTest
     private RecuperarCadastroPorIdUseCase CriarUseCase(SistemaDeCadastro.Domain.Entidades.Cadastro? cadastro = null)
     {
         var repositorio = new CadastroReadOnlyRepositorioBuilder().RecuperarPorId(cadastro).Build();
-
-        return new RecuperarCadastroPorIdUseCase(repositorio);
+        var cache = CachingServiceBuilder.Build();
+        
+        return new RecuperarCadastroPorIdUseCase(repositorio, cache);
     }
 }

--- a/tests/UseCases.Test/Pessoa/RecuperarPorId/RecuperarPessoaPorIdUseCaseTest.cs
+++ b/tests/UseCases.Test/Pessoa/RecuperarPorId/RecuperarPessoaPorIdUseCaseTest.cs
@@ -34,7 +34,8 @@ public class RecuperarPessoaPorIdUseCaseTest
     private RecuperarPessoaPorIdUseCase CriarUseCase(SistemaDeCadastro.Domain.Entidades.Pessoa? pessoa = null)
     {
         var repositorio = new PessoaReadOnlyRepositorioBuilder().RecuperarPorId(pessoa).Build();
-
-        return new RecuperarPessoaPorIdUseCase(repositorio);
+        var cache = CachingServiceBuilder.Build();
+        
+        return new RecuperarPessoaPorIdUseCase(repositorio, cache);
     }
 }

--- a/tests/Utilitarios.Testes/Servicos/CachingServiceBuilder.cs
+++ b/tests/Utilitarios.Testes/Servicos/CachingServiceBuilder.cs
@@ -1,0 +1,13 @@
+using SistemaDeCadastro.Domain.Servicos.CachingService;
+
+namespace Utilitarios.Testes.Servicos;
+
+    public class CachingServiceBuilder
+    {
+        public static ICachingService Build()
+        {
+            var mock = new Mock<ICachingService>();
+
+            return mock.Object;
+        }
+    }


### PR DESCRIPTION
- Erro: erro de teste do caso de uso `RecuperarPorId` onde é necessário adicionar o serviço de cache para criar caso de uso

- Correção: Adiciona builder do serviço de cache criando um mock de `ICachingService`.