### PR TITLE
Adiciona e altera testes de `Cadastro` e `Pessoa` 

### DIFF
--- a/tests/UseCases.Test/Cadastro/RecuperarTodos/RecuperarTodosCadastroUseCaseTest.cs
+++ b/tests/UseCases.Test/Cadastro/RecuperarTodos/RecuperarTodosCadastroUseCaseTest.cs
@@ -12,7 +12,11 @@ public class RecuperarTodosCadastroUseCaseTest
         var resultado = await useCase.Executar();
 
         resultado.Should().NotBeNull();
-        resultado.Should().HaveCountGreaterThan(0);
+        resultado.Cadastros.Should().NotBeNull().And.AllSatisfy(cadastro =>
+        {
+            cadastro.Id.Should().BeGreaterThan(0);
+            cadastro.Email.Should().NotBeNullOrEmpty();
+        });
     }
 
     private RecuperarTodosCadastroUseCase CriarUseCase(List<SistemaDeCadastro.Domain.Entidades.Cadastro> cadastros)

--- a/tests/UseCases.Test/Pessoa/RecuperarTodos/RecuperarTodosPessoaUseCaseTest.cs
+++ b/tests/UseCases.Test/Pessoa/RecuperarTodos/RecuperarTodosPessoaUseCaseTest.cs
@@ -12,7 +12,11 @@ public class RecuperarTodosPessoaUseCaseTest
         var resultado = await useCase.Executar();
 
         resultado.Should().NotBeNull();
-        resultado.Should().HaveCountGreaterThan(0);
+        resultado.Pessoas.Should().NotBeNull().And.AllSatisfy(pessoa =>
+        {
+            pessoa.Id.Should().BeGreaterThan(0);
+            pessoa.Email.Should().NotBeNullOrEmpty();
+        });
     }
 
     private RecuperarTodosPessoaUseCase CriarUseCase(List<SistemaDeCadastro.Domain.Entidades.Pessoa> pessoas)

--- a/tests/WebApi.Test/SistemaDeCadastroClassFixture.cs
+++ b/tests/WebApi.Test/SistemaDeCadastroClassFixture.cs
@@ -8,8 +8,11 @@ public class SistemaDeCadastroClassFixture : IClassFixture<CustomWebApplicationF
     =>
         _httpClient = webApplicationFactory.CreateClient();
 
+    protected async Task<HttpResponseMessage> DoGet(string requestUri)
+    =>  await _httpClient.GetAsync(requestUri);
+    
+
     protected async Task<HttpResponseMessage> DoPost(string requestUri, object request)
-    {
-        return await _httpClient.PostAsJsonAsync(requestUri, request);
-    }
+    => await _httpClient.PostAsJsonAsync(requestUri, request);
+    
 }

--- a/tests/WebApi.Test/Usings.cs
+++ b/tests/WebApi.Test/Usings.cs
@@ -7,14 +7,18 @@ global using Microsoft.AspNetCore.Mvc.Testing;
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.Extensions.DependencyInjection;
 
+global using Moq;
 global using FluentAssertions;
 
 global using SistemaDeCadastro.Domain.Entidades;
+global using SistemaDeCadastro.Domain.Servicos.CachingService;
+
 global using SistemaDeCadastro.Infrastructure.AcessoRepositorio;
 
 global using Utilitarios.Testes.Entidades;
 global using Utilitarios.Testes.Requisicoes.Cadastro;
 global using Utilitarios.Testes.Requisicoes.Pessoa;
+
 
 
 

--- a/tests/WebApi.Test/V1/Cadastro/RecuperarPorId/RecuperarPorIdTest.cs
+++ b/tests/WebApi.Test/V1/Cadastro/RecuperarPorId/RecuperarPorIdTest.cs
@@ -1,0 +1,28 @@
+namespace WebApi.Test.V1.Cadastro.RecuperarPorId;
+
+public class RecuperarPorIdTest : SistemaDeCadastroClassFixture
+{
+    private const string METODO = "cadastro";
+
+    private readonly SistemaDeCadastro.Domain.Entidades.Cadastro _cadastro;
+
+
+    public RecuperarPorIdTest(CustomWebApplicationFactory webApplicationFactory) : base(webApplicationFactory)
+    =>
+        _cadastro = webApplicationFactory.RecuperarCadastro;
+    
+
+    [Fact]
+    public async Task Sucesso()
+    {
+        var resultado = await DoGet(requestUri: $"{METODO}/{_cadastro.Id}");
+
+        resultado.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await resultado.Content.ReadAsStreamAsync();
+
+        var resposta = await JsonDocument.ParseAsync(body);
+
+        resposta.RootElement.GetProperty("id").GetInt64().Should().Be(_cadastro.Id);
+    }
+}

--- a/tests/WebApi.Test/V1/Cadastro/RecuperarTodos/RecuperarTodosTest.cs
+++ b/tests/WebApi.Test/V1/Cadastro/RecuperarTodos/RecuperarTodosTest.cs
@@ -1,0 +1,23 @@
+namespace WebApi.Test.V1.Cadastro.RecuperarTodos;
+
+public class RecuperarTodosTest : SistemaDeCadastroClassFixture
+{
+    private const string METODO = "cadastro";
+
+    public RecuperarTodosTest(CustomWebApplicationFactory webApplicationFactory) : base(webApplicationFactory)
+    { }
+
+    [Fact]
+    public async Task Sucesso()
+    {
+        var resultado = await DoGet(requestUri: METODO);
+
+        resultado.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await resultado.Content.ReadAsStreamAsync();
+
+        var resposta = await JsonDocument.ParseAsync(body);
+
+        resposta.RootElement.GetProperty("cadastros").EnumerateArray().Should().NotBeNullOrEmpty();
+    }
+}

--- a/tests/WebApi.Test/V1/Pessoa/RecuperarPorId/RecuperarPorIdTest.cs
+++ b/tests/WebApi.Test/V1/Pessoa/RecuperarPorId/RecuperarPorIdTest.cs
@@ -1,0 +1,27 @@
+namespace WebApi.Test.V1.Pessoa.RecuperarPorId;
+
+    public class RecuperarPorIdTest : SistemaDeCadastroClassFixture
+{
+    private const string METODO = "pessoa";
+
+    private readonly SistemaDeCadastro.Domain.Entidades.Pessoa _pessoa;
+
+    public RecuperarPorIdTest(CustomWebApplicationFactory webApplicationFactory) : base(webApplicationFactory)
+    =>
+        _pessoa = webApplicationFactory.RecuperarPessoa;
+    
+
+    [Fact]
+    public async Task Sucesso()
+    {
+        var resultado = await DoGet(requestUri: $"{METODO}/{_pessoa.Id}");
+
+        resultado.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await resultado.Content.ReadAsStreamAsync();
+
+        var resposta = await JsonDocument.ParseAsync(body);
+
+        resposta.RootElement.GetProperty("id").GetInt64().Should().Be(_pessoa.Id);
+    }
+}

--- a/tests/WebApi.Test/V1/Pessoa/RecuperarTodos/RecuperarTodosTest.cs
+++ b/tests/WebApi.Test/V1/Pessoa/RecuperarTodos/RecuperarTodosTest.cs
@@ -1,0 +1,23 @@
+namespace WebApi.Test.V1.Pessoa.RecuperarTodos;
+
+public class RecuperarTodosTest : SistemaDeCadastroClassFixture
+{
+    private const string METODO = "pessoa";
+
+    public RecuperarTodosTest(CustomWebApplicationFactory webApplicationFactory) : base(webApplicationFactory)
+    { }
+
+    [Fact]
+    public async Task Sucesso()
+    {
+        var resultado = await DoGet(requestUri: METODO);
+
+        resultado.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await resultado.Content.ReadAsStreamAsync();
+
+        var resposta = await JsonDocument.ParseAsync(body);
+
+        resposta.RootElement.GetProperty("pessoas").EnumerateArray().Should().NotBeNullOrEmpty();
+    }
+}


### PR DESCRIPTION
- Adiciona `get` para recuperar entidades criadas e utilizar seus `Ids` no teste de `RecuperarPorId` 
- Adiciona mock do serviço `ICachingService` 
- Melhora teste do caso de uso `RecuperarTodos` fazendo validação da lista retornada
- Adiciona teste dos endpoints `RecuperarTodos` e `RecuperarPorId` de `Cadastro` e `Pessoa`